### PR TITLE
feat: embed html file in Go binary

### DIFF
--- a/go/index.html.tmpl
+++ b/go/index.html.tmpl
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Go App on deplo.io</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="" />
+  <meta name="theme-color" content="">
+
+  <style>
+  body {
+    background-color: #141d50;
+    color: #ffffff;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+     'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+     'Droid Sans', 'Helvetica Neue', 'Segoe UI Emoji',
+     'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
+  }
+  .logo {
+    filter: invert(1);
+    width: 30%;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  </style>
+</head>
+
+<body>
+  <h1 style="text-align:center">Go App</h1>
+  <img class="logo" src="https://docs.nine.ch/img/theme/deploio.svg"></img>
+  <p style="text-align:center">RESPONSE_TEXT: {{.Text}}</p>
+</body>
+
+</html>


### PR DESCRIPTION
this brings the example in line with the others and also demonstrates how files can be embedded directly into the binary so they are available on deplo.io without needing to resort to special build envs.