### PR TITLE
docs: wrap commands earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ are being supported by deplo.io.
 ## Go
 
 ```bash
-nctl create application go --git-url=https://github.com/ninech/deploio-examples --git-sub-path=go
+nctl create application go \
+  --git-url=https://github.com/ninech/deploio-examples \
+  --git-sub-path=go
 ```
 
 ## Ruby
@@ -15,18 +17,24 @@ This requires the `rails` command to be installed for the `SECRET_KEY_BASE`.
 If you don't have it, any long random string will do (127+ chars).
 
 ```bash
-nctl create application rails --git-url=https://github.com/ninech/deploio-examples --git-sub-path=ruby/rails-basic \
- --env=SECRET_KEY_BASE=$(rails secret)
+nctl create application rails \
+  --git-url=https://github.com/ninech/deploio-examples \
+  --git-sub-path=ruby/rails-basic \
+  --env=SECRET_KEY_BASE=$(rails secret)
 ```
 
 ## Node.js
 
 ```bash
-nctl create application nextjs --git-url=https://github.com/ninech/deploio-examples --git-sub-path=nodejs/nextjs
+nctl create application nextjs \
+  --git-url=https://github.com/ninech/deploio-examples \
+  --git-sub-path=nodejs/nextjs
 ```
 
 ## PHP
 
 ```bash
-nctl create application symfony --git-url=https://github.com/ninech/deploio-examples --git-sub-path=php/symfony
+nctl create application symfony \
+  --git-url=https://github.com/ninech/deploio-examples \
+  --git-sub-path=php/symfony
 ```


### PR DESCRIPTION
The markdown preview that shows up when viewing a file is wider than the GitHub main page. So to avoid horizontal scrolling we wrap all the commands.