### PR TITLE
add exit injection via env for Go app

### DIFF
--- a/.github/workflows/build-push-go.yml
+++ b/.github/workflows/build-push-go.yml
@@ -35,5 +35,7 @@ jobs:
             --path ./go \
             --builder paketobuildpacks/builder-jammy-buildpackless-static \
             --buildpack paketo-buildpacks/go \
+            --env "CGO_ENABLED=0" \
+            --env "BP_GO_BUILD_FLAGS=-buildmode=default" \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
             --publish

--- a/.github/workflows/build-push-go.yml
+++ b/.github/workflows/build-push-go.yml
@@ -1,0 +1,39 @@
+name: build-push-go
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-push-go:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+      ARCH: "amd64"
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}-go
+      DOCKER_IMAGE_TAG: ${{ github.sha }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up pack
+        uses: buildpacks/github-actions/setup-pack@v5.0.0
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: build
+        run: |
+          pack build ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_IMAGE_TAG }} \
+            --path ./go \
+            --builder paketobuildpacks/builder-jammy-buildpackless-static \
+            --buildpack paketo-buildpacks/go \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            --publish

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/ctrox/go-sample
+module github.com/deploio-examples/go
 
 go 1.19

--- a/go/main.go
+++ b/go/main.go
@@ -14,6 +14,7 @@ import (
 const (
 	responseEnvKey = "RESPONSE_TEXT"
 	portEnvKey     = "PORT"
+	exitEnvKey     = "DEBUG_EXIT"
 	realIPHeader   = "X-Forwarded-For"
 	defaultPort    = 8080
 )
@@ -22,6 +23,15 @@ const (
 var content embed.FS
 
 func main() {
+	if val, ok := os.LookupEnv(exitEnvKey); ok {
+		code, err := strconv.Atoi(val)
+		if err != nil {
+			log.Fatalf("error parsing exit code %s to int: %s", val, err)
+		}
+		log.Printf("exiting with code %v requested by env %s", code, exitEnvKey)
+		os.Exit(code)
+	}
+
 	tmpl, err := template.ParseFS(content, "*.tmpl")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
for our e2e tests we want a deplo.io app that exits with a certain code
so we can test some of the status handling. So e.g. when setting the env
var DEBUG_EXIT=2, the go app will exit with code 2.

The second commit adds an action to build the go app and upload the image so we can use it in our e2e tests.