### PR TITLE
fix: use builder-base instead of static builder

### DIFF
--- a/.github/workflows/build-push-go.yml
+++ b/.github/workflows/build-push-go.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pack build ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_IMAGE_TAG }} \
             --path ./go \
-            --builder paketobuildpacks/builder-jammy-buildpackless-static \
+            --builder paketobuildpacks/builder:base \
             --buildpack paketo-buildpacks/go \
             --env "CGO_ENABLED=0" \
             --env "BP_GO_BUILD_FLAGS=-buildmode=default" \


### PR DESCRIPTION
with the static builder the resulting image only has the actual go binary available. Since we want to use things such as `sleep` in our e2e tests (to test deploy job timeouts) we use builder-base which includes a few more binaries.