### PR TITLE
delete special nginx conf

### DIFF
--- a/php/symfony/.nginx.conf.d/location-server.conf
+++ b/php/symfony/.nginx.conf.d/location-server.conf
@@ -1,3 +1,0 @@
-location / {
-    try_files $uri $uri/ /index.php?$args;
-}


### PR DESCRIPTION
The root location block will be added by "buildpack-php-nginx" by default, so we can get rid of this special file now.