### PR TITLE
fix: add bundle platform x86_64-linux

### DIFF
--- a/ruby/rails-basic/Gemfile.lock
+++ b/ruby/rails-basic/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.6)
     minitest (5.19.0)
     msgpack (1.7.2)
     net-imap (0.3.7)
@@ -125,7 +126,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.3-arm64-darwin)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     public_suffix (5.0.3)
     puma (5.6.6)
@@ -179,7 +181,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.3-arm64-darwin)
+    sqlite3 (1.6.3)
+      mini_portile2 (~> 2.8.0)
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     thor (1.2.2)
@@ -208,7 +211,9 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap
@@ -231,4 +236,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.10
+   2.5.9


### PR DESCRIPTION
depending on the bundle version this is enforced and will cause the build to fail on `x86_64-linux`.